### PR TITLE
[Deployment] v1.0.2

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,7 @@
       name="description"
       content="마비노기 모바일 스텔라그램 UGC SNS 서비스"
     />
+    <meta name="google-adsense-account" content="ca-pub-3581534207395265" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/app/public/ads.txt
+++ b/app/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-3581534207395265, DIRECT, f08c47fec0942fa0

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /compose/
+Disallow: /message/
+Disallow: /profile/*/followers
+Disallow: /profile/*/following

--- a/app/src/components/composer/PostComposerMedia.tsx
+++ b/app/src/components/composer/PostComposerMedia.tsx
@@ -2,10 +2,11 @@ import { PostMediaStructure } from "../../Types";
 import MediaContent from "../post/MediaContent";
 import IconButton from "../button/IconButton";
 import usePostComposerStore from "../../store/PostComposerStore";
+import { useState } from "react";
 
 function PostComposerMedia() {
   const POST_MEDIAFIELD_ID = "post-media";
-  const childMediaContext = { index: 0 };
+  const [mediaIndex, setState] = useState(0);
   const mediaFiles = usePostComposerStore((state) => state.mediaContentList);
   const removeMediaFile = usePostComposerStore(
     (state) => state.removeMediaContent
@@ -19,7 +20,11 @@ function PostComposerMedia() {
           <IconButton
             icon="xmark"
             size={18}
-            onPressed={() => removeMediaFile(childMediaContext.index)}
+            onPressed={() => {
+              if (mediaIndex == mediaFiles.length - 1)
+                setState((prev) => prev - 1);
+              removeMediaFile(mediaIndex);
+            }}
           />
         </div>
       )}
@@ -31,7 +36,7 @@ function PostComposerMedia() {
               type: file.type.split("/")[0],
             } as PostMediaStructure;
           })}
-          context={childMediaContext}
+          context={[mediaIndex, setState]}
           post_id="mediafield"
         />
       )}

--- a/app/src/components/post/Content.tsx
+++ b/app/src/components/post/Content.tsx
@@ -28,7 +28,7 @@ function Content(post: Post) {
   };
 
   return (
-    <div
+    <article
       role="button"
       className="cursor-pointer"
       onClick={() =>
@@ -79,7 +79,7 @@ function Content(post: Post) {
           </div>
         </div>
       </div>
-    </div>
+    </article>
   );
 }
 

--- a/app/src/components/post/MediaContent.tsx
+++ b/app/src/components/post/MediaContent.tsx
@@ -8,16 +8,22 @@ import iconPack from "../public/IconPack";
 type MediaContentProps = {
   contents: PostMediaStructure[];
   post_id: string;
-  context?: { index: number };
+  context?: [
+    mediaIndex: number,
+    setState: React.Dispatch<React.SetStateAction<number>>
+  ];
 };
 
 function MediaContent({ contents, post_id, context }: MediaContentProps) {
-  const [mediaIndex, setState] = useState(0);
+  const [mediaIndex, setState] = context ?? useState(0);
   const userAgent = navigator.userAgent.toLowerCase();
   const isDesktop = !/mobile|tablet|ip(ad|hone|od)|android/i.test(userAgent);
 
-  if (mediaIndex >= contents.length) setState(contents.length - 1);
-  if (context != null) context.index = mediaIndex;
+  if (mediaIndex >= contents.length) {
+    setState(contents.length - 1);
+    return <></>;
+  }
+  // if (context != null) context.index = mediaIndex;
 
   useEffect(() => {
     if (isDesktop) {

--- a/app/src/components/public/IconPack.tsx
+++ b/app/src/components/public/IconPack.tsx
@@ -17,15 +17,15 @@ export default function iconPack(iconName) {
         <svg id="compose" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             d="M16.4745 5.40801L18.5917 7.52524M17.8358 3.54289L12.1086 9.27005C11.8131 9.56562 11.6116 9.94206 11.5296 10.3519L11 13L13.6481 12.4704C14.0579 12.3884 14.4344 12.1869 14.7299 11.8914L20.4571 6.16423C21.181 5.44037 21.181 4.26676 20.4571 3.5429C19.7332 2.81904 18.5596 2.81903 17.8358 3.54289Z"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.6"
           />
           <path
             d="M19 15V18C19 19.1046 18.1046 20 17 20H6C4.89543 20 4 19.1046 4 18V7C4 5.89543 4.89543 5 6 5H9"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.4"
           />
         </svg>
       );
@@ -70,16 +70,16 @@ export default function iconPack(iconName) {
           <title />
           <g data-name="1" id="_1">
             <path
-              stroke-width="10"
-              d="M441.13,166.52h-372a15,15,0,1,1,0-30h372a15,15,0,0,1,0,30Z"
+              strokeWidth="10"
+              d="M441.13,146.52h-372a15,15,0,1,1,0-30h372a15,15,0,0,1,0,30Z"
             />
             <path
-              stroke-width="10"
+              strokeWidth="10"
               d="M441.13,279.72h-372a15,15,0,1,1,0-30h372a15,15,0,0,1,0,30Z"
             />
             <path
-              stroke-width="10"
-              d="M441.13,392.92h-372a15,15,0,1,1,0-30h372a15,15,0,0,1,0,30Z"
+              strokeWidth="10"
+              d="M441.13,412.92h-372a15,15,0,1,1,0-30h372a15,15,0,0,1,0,30Z"
             />
           </g>
         </svg>
@@ -93,9 +93,9 @@ export default function iconPack(iconName) {
           viewBox="0 0 512 512"
         >
           <g>
-            <circle cx="256" cy="256" r="32" stroke-width="40" />
-            <circle cx="88.4" cy="256" r="32" stroke-width="40" />
-            <circle cx="424" cy="256" r="32" stroke-width="40" />
+            <circle cx="256" cy="256" r="32" strokeWidth="40" />
+            <circle cx="88.4" cy="256" r="32" strokeWidth="40" />
+            <circle cx="424" cy="256" r="32" strokeWidth="40" />
           </g>
         </svg>
       );
@@ -179,9 +179,9 @@ export default function iconPack(iconName) {
           id="signout"
           fill="none"
           stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="3"
           viewBox="0 0 24 24"
         >
           <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -231,9 +231,9 @@ export default function iconPack(iconName) {
           id="chevron-left"
           fill="none"
           stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
           viewBox="0 0 24 24"
         >
           <polyline points="15 18 9 12 15 6" />
@@ -245,9 +245,9 @@ export default function iconPack(iconName) {
           id="chevron-right"
           fill="none"
           stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
           viewBox="0 0 24 24"
         >
           <polyline points="9 6 15 12 9 18" />
@@ -259,9 +259,9 @@ export default function iconPack(iconName) {
           id="chevron-right"
           fill="none"
           stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
           viewBox="0 0 24 24"
         >
           <polyline points="6 15 12 9 18 15" />
@@ -311,9 +311,9 @@ export default function iconPack(iconName) {
           id="check"
           fill="none"
           stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
           viewBox="0 0 24 24"
         >
           <polyline points="20 6 9 17 4 12" />

--- a/app/src/layouts/Profile.tsx
+++ b/app/src/layouts/Profile.tsx
@@ -37,16 +37,16 @@ export default function Profile() {
   const wideViewStandard = 1000;
   const checkWideView = () => window.innerWidth > wideViewStandard;
 
-  const resizeEvent = () => {
-    const sideElement = document.getElementById("side")!;
-    const isSideExist = sideElement.style.display === "block";
+  // const resizeEvent = () => {
+  //   const sideElement = document.getElementById("side")!;
+  //   const isSideExist = sideElement.style.display === "block";
 
-    if (isSideExist && !checkWideView()) {
-      sideElement.style.display = "none";
-    } else if (!isSideExist && checkWideView()) {
-      sideElement.style.display = "block";
-    }
-  };
+  //   if (isSideExist && !checkWideView()) {
+  //     sideElement.style.display = "none";
+  //   } else if (!isSideExist && checkWideView()) {
+  //     sideElement.style.display = "block";
+  //   }
+  // };
 
   const deletePost = (postId: string) => {
     setPostList((prev) => prev.filter((post) => post.post_id !== postId));
@@ -257,10 +257,10 @@ export default function Profile() {
     likePostRef.current = likePostList;
   }, [likePostList]);
 
-  useEffect(() => {
-    window.addEventListener("resize", resizeEvent);
-    return () => window.removeEventListener("resize", resizeEvent);
-  }, []);
+  // useEffect(() => {
+  //   window.addEventListener("resize", resizeEvent);
+  //   return () => window.removeEventListener("resize", resizeEvent);
+  // }, []);
 
   return (
     <div id="scaffold" className="w-full h-screen mx-auto content-start">


### PR DESCRIPTION

## 오류가 수정되었습니다

- 포스트 컴포저 마지막 미디어 콘텐츠 제거 문제 해결
  
  변경 내용: 포스트 컴포저의 미디어 콘텐츠 인덱스 상태 관리를 미디어
콘텐츠가 아닌 컴포저에서 전달하는 방식으로 변경하였습니다.

  변경 사유: 미디어 콘텐츠가 2개 이상일 때 마지막 콘텐츠를 제거하면
인덱스가 변경된 상태에서 리렌더링이 발생하지 않아 에러가 발생하여 이를
해결하였습니다.

- IconPack에서 정의한 아이콘 중 허용되지 않는 옵션 이름이 있어 이를
변경하였습니다.

  예시: stroke-linecap -> strokeLinecap

- 아직 사용되지 않는 컴포넌트를 대비한 화면 리사이징 이벤트를
주석처리하였습니다. (Profile 레이아웃)


## 설정이 추가되었습니다

- index.html에 adsense 봇이 식별할 수 있는 광고 게시자 ID를
  추가하였습니다.

- ads.txt를 추가하여 허용중인 광고 발행 업체를 표시하였습니다.

- robots.txt를 추가하여 봇이 크롤링하지 않아야 하는 페이지를
  표시하였습니다.